### PR TITLE
Bugfix: Only capture fence when validate() succeeds

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,9 +71,8 @@ export default function (md, name, opts) {
     len = state.sCount[startLine]
     state.line = nextLine + (haveEndMarker ? 1 : 0)
 
-    let token
-    if (options.validate(params)) token = state.push(name, 'div', 0)
-    else token = state.push('fence', 'code', 0)
+    if (!options.validate(params)) return false
+    const token = state.push(name, 'div', 0)
     token.info = params
     token.content = state.getLines(startLine + 1, nextLine, len, true)
     token.markup = markup

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -38,6 +38,32 @@ I'm testing
   expect(md.use(plugin).render(testStr)).toBe(res)
 })
 
+test('multiple plugins', () => {
+  const testStr = `
+:::test1
+I'm testing
+:::
+
+:::test2
+I'm another test
+:::
+  `
+  const plugin1 = () => {
+    mdFence(md, 'test1', {
+      marker: ':',
+      render: () => '(a)'
+    })
+  }
+  const plugin2 = () => {
+    mdFence(md, 'test2', {
+      marker: ':',
+      render: () => '(b)'
+    })
+  }
+
+  expect(md.use(plugin1).use(plugin2).render(testStr)).toBe('(a)(b)')
+})
+
 test('default render test', () => {
   const testStr = `
 \`\`\`


### PR DESCRIPTION
I discovered that when I had two copies of `markdown-it-fence` installed (to render two different kinds of block), only the first install would do anything; the second one would fall through to being a “regular fence” (even if it had a custom marker configured) and HighlightJS would complain it didn’t know what to do.

I’m not entirely clear what the previous code was doing, so I may have messed up some use case. In particular, it seems like even if the validation fails (so the block doesn’t match), it was doing `state.push('fence', 'code', 0)` for some reason? I deleted that bit of code and confirmed that regular fenced blocks are still working as expected for me, but I’m not sure what the intent was behind that logic.