### PR TITLE
Support installing from git

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:cov": "jest --coverage && npm run lint",
     "test": "jest && npm run lint && npm run build",
     "lint": "xo",
+    "prepare": "bili --name index",
     "build": "bili --name index"
   },
   "author": "GeekPlux <geekplux@gmail.com> (http://geekplux.com/)",


### PR DESCRIPTION
Useful when preparing patches, to be able to install the package from GitHub before a new version is released.